### PR TITLE
addJenkinsPipeline: add support for Jenkins pipeline (aka Jenkinsfile)

### DIFF
--- a/github-coverage-reporter.iml
+++ b/github-coverage-reporter.iml
@@ -17,7 +17,7 @@
     <orderEntry type="library" scope="TEST" name="com.github.paweladamski:HttpClientMock:Latest" level="project" />
     <orderEntry type="library" name="Maven: org.jenkins-ci.plugins:structs:1.7" level="project" />
     <orderEntry type="library" name="Maven: org.jenkins-ci:symbol-annotation:1.7" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.jenkins-ci.plugins.workflow:workflow-step-api:2.12" level="project" />
+    <orderEntry type="library" name="Maven: org.jenkins-ci.plugins.workflow:workflow-step-api:2.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.jenkins-ci.plugins.workflow:workflow-cps:2.39" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.jenkins-ci.plugins.workflow:workflow-scm-step:2.4" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.jenkins-ci.plugins:script-security:1.31" level="project" />
@@ -49,6 +49,7 @@
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.2.3" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.2.3" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.2.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.jenkins-ci:annotation-indexer:1.12" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.code.findbugs:annotations:3.0.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: net.jcip:jcip-annotations:1.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.codehaus.mojo:animal-sniffer-annotations:1.14" level="project" />
@@ -101,7 +102,6 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: net.sf.ezmorph:ezmorph:1.0.6" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: commons-httpclient:commons-httpclient:3.1-jenkins-1" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: args4j:args4j:2.0.31" level="project" />
-    <orderEntry type="library" name="Maven: org.jenkins-ci:annotation-indexer:1.12" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.jenkins-ci:bytecode-compatibility-transformer:2.0-beta-2" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.kohsuke:asm6:6.2" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.jenkins-ci:task-reactor:1.5" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
             <version>2.12</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,12 @@
             <artifactId>github-api</artifactId>
             <version>1.71</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci</groupId>
+            <artifactId>annotation-indexer</artifactId>
+            <version>1.12</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/io/jenkins/plugins/gcr/GithubCoveragePublisher.java
+++ b/src/main/java/io/jenkins/plugins/gcr/GithubCoveragePublisher.java
@@ -34,185 +34,183 @@ import org.kohsuke.stapler.StaplerRequest;
 
 public class GithubCoveragePublisher extends Recorder {
 
-	public static final int COMPARISON_SONAR = 0;
-	public static final int COMPARISON_FIXED = 1;
+    public static final int COMPARISON_SONAR = 0;
+    public static final int COMPARISON_FIXED = 1;
 
-	private final String filepath;
+    private final String filepath;
 
-	private String coverageXmlType;
+    private String coverageXmlType;
 
-	private String coverageRateType;
+    private String coverageRateType;
 
-	private ComparisonOption comparisonOption;
+    private ComparisonOption comparisonOption;
 
-	@DataBoundConstructor
-	public GithubCoveragePublisher(String filepath, String coverageXmlType, String coverageRateType, ComparisonOption comparisonOption) throws IOException {
-		this.filepath = filepath;
-		this.coverageXmlType = coverageXmlType;
-		this.coverageRateType = coverageRateType;
-		this.comparisonOption = comparisonOption;
-	}
+    @DataBoundConstructor
+    public GithubCoveragePublisher(String filepath, String coverageXmlType, String coverageRateType, ComparisonOption comparisonOption) throws IOException {
+        this.filepath = filepath;
+        this.coverageXmlType = coverageXmlType;
+        this.coverageRateType = coverageRateType;
+        this.comparisonOption = comparisonOption;
+    }
 
-	@Override
-	public DescriptorImpl getDescriptor() {
-		return (DescriptorImpl)super.getDescriptor();
-	}
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return (DescriptorImpl) super.getDescriptor();
+    }
 
-	// Getters / Setters
+    // Getters / Setters
 
-	public String getFilepath() {
-		return filepath;
-	}
+    public String getFilepath() {
+        return filepath;
+    }
 
-	public String getCoverageXmlType() {
-		return coverageXmlType;
-	}
+    public String getCoverageXmlType() {
+        return coverageXmlType;
+    }
 
-	@DataBoundSetter
-	public void setCoverageXmlType(String coverageXmlType) {
-		this.coverageXmlType = coverageXmlType;
-	}
+    @DataBoundSetter
+    public void setCoverageXmlType(String coverageXmlType) {
+        this.coverageXmlType = coverageXmlType;
+    }
 
-	public ComparisonOption getComparisonOption() {
-		return comparisonOption;
-	}
+    public ComparisonOption getComparisonOption() {
+        return comparisonOption;
+    }
 
-	@DataBoundSetter
-	public void setComparisonOption(ComparisonOption comparisonOption) {
-		this.comparisonOption = comparisonOption;
-	}
+    @DataBoundSetter
+    public void setComparisonOption(ComparisonOption comparisonOption) {
+        this.comparisonOption = comparisonOption;
+    }
 
-	public String getSonarProject() {
-		return this.comparisonOption.getSonarProject();
-	}
+    public String getSonarProject() {
+        return this.comparisonOption.getSonarProject();
+    }
 
-	public String getCoverageRateType() {
-		return coverageRateType;
-	}
+    public String getCoverageRateType() {
+        return coverageRateType;
+    }
 
-	@DataBoundSetter
-	public void setCoverageRateType(String coverageRateType) {
-		this.coverageRateType = coverageRateType;
-	}
+    @DataBoundSetter
+    public void setCoverageRateType(String coverageRateType) {
+        this.coverageRateType = coverageRateType;
+    }
 
-	@Override
-	public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
-			throws InterruptedException,IOException {
-		
-		if (build==null) {
-			return false;
-		}
-		FilePath workspace = build.getWorkspace();
-		if (workspace==null) {
-			return false;
-		}
-		return publishCoverage(build, workspace, listener, build.getEnvironment(listener), filepath, coverageXmlType,comparisonOption,coverageRateType);
-	}
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+            throws InterruptedException, IOException {
 
-	public static boolean publishCoverage(Run<?, ?> build, FilePath workspace, TaskListener listener, EnvVars env,  String filepath, String coverageXmlType, io.jenkins.plugins.gcr.models.ComparisonOption comparisonOption, String coverageRateType) throws InterruptedException, IOException {
-		listener.getLogger().println("build: Attempting to parse file of type, " + coverageXmlType + "");
+        if (build == null) {
+            return false;
+        }
+        FilePath workspace = build.getWorkspace();
+        if (workspace == null) {
+            return false;
+        }
+        return publishCoverage(build, workspace, listener, build.getEnvironment(listener), filepath, coverageXmlType, comparisonOption, coverageRateType);
+    }
 
-		PluginEnvironment environment = new PluginEnvironment(env);
-		String githubAccessToken = PluginConfiguration.DESCRIPTOR.getGithubAccessToken();
-		String githubUrl = PluginConfiguration.DESCRIPTOR.getGithubEnterpriseUrl();
-		GithubClient githubClient = new GithubClient(environment, githubUrl, githubAccessToken);
+    public static boolean publishCoverage(Run<?, ?> build, FilePath workspace, TaskListener listener, EnvVars env, String filepath, String coverageXmlType, io.jenkins.plugins.gcr.models.ComparisonOption comparisonOption, String coverageRateType) throws InterruptedException, IOException {
+        listener.getLogger().println("build: Attempting to parse file of type, " + coverageXmlType + "");
 
-		FilePath pathToFile = workspace.child(filepath);
+        PluginEnvironment environment = new PluginEnvironment(env);
+        String githubAccessToken = PluginConfiguration.DESCRIPTOR.getGithubAccessToken();
+        String githubUrl = PluginConfiguration.DESCRIPTOR.getGithubEnterpriseUrl();
+        GithubClient githubClient = new GithubClient(environment, githubUrl, githubAccessToken);
 
-		if (!pathToFile.exists()) {
-			listener.error("The coverage file at the provided path does not exist");
-			build.setResult(Result.FAILURE);
-			return false;
-		} else {
-			listener.getLogger().println(String.format("Found file '%s'", filepath));
+        FilePath pathToFile = workspace.child(filepath);
+
+        if (!pathToFile.exists()) {
+            listener.error("The coverage file at the provided path does not exist");
+            build.setResult(Result.FAILURE);
+            return false;
+        } else {
+            listener.getLogger().println(String.format("Found file '%s'", filepath));
 //            String xmlString = FileUtils.readFileToString(new File(pathToFile.toURI()));
-		}
+        }
 
-		BuildStepService buildStepService = new BuildStepService();
+        BuildStepService buildStepService = new BuildStepService();
 
-		try {
-			CoverageReportAction coverageReport = buildStepService.generateCoverageReport(pathToFile, comparisonOption, coverageXmlType, coverageRateType);
-			build.addAction(coverageReport);
-			build.save();
+        try {
+            CoverageReportAction coverageReport = buildStepService.generateCoverageReport(pathToFile, comparisonOption, coverageXmlType, coverageRateType);
+            build.addAction(coverageReport);
+            build.save();
 
-			GithubPayload payload = buildStepService.generateGithubCovergePayload(coverageReport, environment.getBuildUrl());
-			githubClient.sendCommitStatus(payload);
+            GithubPayload payload = buildStepService.generateGithubCovergePayload(coverageReport, environment.getBuildUrl());
+            githubClient.sendCommitStatus(payload);
 
-			build.setResult(Result.SUCCESS);
-		} catch (Exception ex) {
-			listener.error(ex.getMessage());
-			ex.printStackTrace();
-			build.setResult(Result.FAILURE);
-			return false;
-		}
-		return true;
-	}
+            build.setResult(Result.SUCCESS);
+        } catch (Exception ex) {
+            listener.error(ex.getMessage());
+            ex.printStackTrace();
+            build.setResult(Result.FAILURE);
+            return false;
+        }
+        return true;
+    }
 
-	@Extension
-	public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
-
-
+    @Extension
+    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 
 
-		private ListBoxModel sonarProjectModel;
+        private ListBoxModel sonarProjectModel;
 
-		public ListBoxModel doFillCoverageXmlTypeItems() {
-			// TODO: localise
-			ListBoxModel model = new ListBoxModel();
-			model.add("Cobertura XML", CoverageType.COBERTURA.getIdentifier());
-			model.add("Jacoco XML", CoverageType.JACOCO.getIdentifier());
-			return model;
-		}
+        public ListBoxModel doFillCoverageXmlTypeItems() {
+            // TODO: localise
+            ListBoxModel model = new ListBoxModel();
+            model.add("Cobertura XML", CoverageType.COBERTURA.getIdentifier());
+            model.add("Jacoco XML", CoverageType.JACOCO.getIdentifier());
+            return model;
+        }
 
-		public ListBoxModel doFillSonarProjectItems() {
-			sonarProjectModel = new ListBoxModel();
+        public ListBoxModel doFillSonarProjectItems() {
+            sonarProjectModel = new ListBoxModel();
 
-			SonarClient client = new SonarClient();
-			try {
-				List<SonarProject> projects = client.listProjects();
-				projects.forEach(project -> sonarProjectModel.add(project.getName(), project.getKey()));
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
+            SonarClient client = new SonarClient();
+            try {
+                List<SonarProject> projects = client.listProjects();
+                projects.forEach(project -> sonarProjectModel.add(project.getName(), project.getKey()));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
 
-			return sonarProjectModel;
-		}
+            return sonarProjectModel;
+        }
 
-		public ListBoxModel doFillCoverageRateTypeItems() {
-			ListBoxModel model = new ListBoxModel();
-			// TODO: localise
-			model.add("Overall", CoverageRateType.OVERALL.getName());
-			model.add("Branch", CoverageRateType.BRANCH.getName());
-			model.add("Line", CoverageRateType.LINE.getName());
-			return model;
-		}
+        public ListBoxModel doFillCoverageRateTypeItems() {
+            ListBoxModel model = new ListBoxModel();
+            // TODO: localise
+            model.add("Overall", CoverageRateType.OVERALL.getName());
+            model.add("Branch", CoverageRateType.BRANCH.getName());
+            model.add("Line", CoverageRateType.LINE.getName());
+            return model;
+        }
 
-		public FormValidation doCheckSonarProject(@QueryParameter String value) {
-			// TODO: Use localized Messages strings
-			if (sonarProjectModel == null || sonarProjectModel.isEmpty()) {
-				return FormValidation.error("SonarQube server unreachable.");
-			}
-			if (value == null || value.equals("")) {
-				return FormValidation.error("Invalid project selection. check that your SonarQube server is not unreachable.");
-			}
+        public FormValidation doCheckSonarProject(@QueryParameter String value) {
+            // TODO: Use localized Messages strings
+            if (sonarProjectModel == null || sonarProjectModel.isEmpty()) {
+                return FormValidation.error("SonarQube server unreachable.");
+            }
+            if (value == null || value.equals("")) {
+                return FormValidation.error("Invalid project selection. check that your SonarQube server is not unreachable.");
+            }
 
-			return FormValidation.ok();
-		}
+            return FormValidation.ok();
+        }
 
-		@Override
-		public boolean isApplicable(Class<? extends AbstractProject> aClass) {
-			return true;
-		}
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+            return true;
+        }
 
-		@Override
-		public String getDisplayName() {
-			return Messages.GithubCoveragePublisher_DescriptorImpl_DisplayName();
-		}
+        @Override
+        public String getDisplayName() {
+            return Messages.GithubCoveragePublisher_DescriptorImpl_DisplayName();
+        }
 
-	}
+    }
 
-	@Override
-	public BuildStepMonitor getRequiredMonitorService() {
-		return BuildStepMonitor.NONE;
-	}
+    @Override
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.NONE;
+    }
 }

--- a/src/main/java/io/jenkins/plugins/gcr/GithubCoveragePublisher.java
+++ b/src/main/java/io/jenkins/plugins/gcr/GithubCoveragePublisher.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.gcr;
 
+import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.Extension;
 import hudson.FilePath;
@@ -31,175 +32,187 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
-public class GithubCoveragePublisher extends Recorder implements SimpleBuildStep {
+public class GithubCoveragePublisher extends Recorder {
 
-    public static final int COMPARISON_SONAR = 0;
-    public static final int COMPARISON_FIXED = 1;
+	public static final int COMPARISON_SONAR = 0;
+	public static final int COMPARISON_FIXED = 1;
 
-    private final String filepath;
+	private final String filepath;
 
-    private String coverageXmlType;
+	private String coverageXmlType;
 
-    private String coverageRateType;
+	private String coverageRateType;
 
-    private ComparisonOption comparisonOption;
+	private ComparisonOption comparisonOption;
 
-    @DataBoundConstructor
-    public GithubCoveragePublisher(String filepath, String coverageXmlType, String coverageRateType, ComparisonOption comparisonOption) throws IOException {
-        this.filepath = filepath;
-        this.coverageXmlType = coverageXmlType;
-        this.coverageRateType = coverageRateType;
-        this.comparisonOption = comparisonOption;
-    }
+	@DataBoundConstructor
+	public GithubCoveragePublisher(String filepath, String coverageXmlType, String coverageRateType, ComparisonOption comparisonOption) throws IOException {
+		this.filepath = filepath;
+		this.coverageXmlType = coverageXmlType;
+		this.coverageRateType = coverageRateType;
+		this.comparisonOption = comparisonOption;
+	}
 
-    @Override
-    public DescriptorImpl getDescriptor() {
-        return (DescriptorImpl)super.getDescriptor();
-    }
+	@Override
+	public DescriptorImpl getDescriptor() {
+		return (DescriptorImpl)super.getDescriptor();
+	}
 
-    // Getters / Setters
+	// Getters / Setters
 
-    public String getFilepath() {
-        return filepath;
-    }
+	public String getFilepath() {
+		return filepath;
+	}
 
-    public String getCoverageXmlType() {
-        return coverageXmlType;
-    }
+	public String getCoverageXmlType() {
+		return coverageXmlType;
+	}
 
-    @DataBoundSetter
-    public void setCoverageXmlType(String coverageXmlType) {
-        this.coverageXmlType = coverageXmlType;
-    }
+	@DataBoundSetter
+	public void setCoverageXmlType(String coverageXmlType) {
+		this.coverageXmlType = coverageXmlType;
+	}
 
-    public ComparisonOption getComparisonOption() {
-        return comparisonOption;
-    }
+	public ComparisonOption getComparisonOption() {
+		return comparisonOption;
+	}
 
-    @DataBoundSetter
-    public void setComparisonOption(ComparisonOption comparisonOption) {
-        this.comparisonOption = comparisonOption;
-    }
+	@DataBoundSetter
+	public void setComparisonOption(ComparisonOption comparisonOption) {
+		this.comparisonOption = comparisonOption;
+	}
 
-    public String getSonarProject() {
-        return this.comparisonOption.getSonarProject();
-    }
+	public String getSonarProject() {
+		return this.comparisonOption.getSonarProject();
+	}
 
-    public String getCoverageRateType() {
-        return coverageRateType;
-    }
+	public String getCoverageRateType() {
+		return coverageRateType;
+	}
 
-    @DataBoundSetter
-    public void setCoverageRateType(String coverageRateType) {
-        this.coverageRateType = coverageRateType;
-    }
+	@DataBoundSetter
+	public void setCoverageRateType(String coverageRateType) {
+		this.coverageRateType = coverageRateType;
+	}
 
-    // Runner
+	@Override
+	public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+			throws InterruptedException,IOException {
+		
+		if (build==null) {
+			return false;
+		}
+		FilePath workspace = build.getWorkspace();
+		if (workspace==null) {
+			return false;
+		}
+		return publishCoverage(build, workspace, listener, build.getEnvironment(listener), filepath, coverageXmlType,comparisonOption,coverageRateType);
+	}
 
-    @Override
-    public void perform(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener) throws InterruptedException, IOException {
-        listener.getLogger().println("Attempting to parse file of type, " + coverageXmlType + "");
+	public static boolean publishCoverage(Run<?, ?> build, FilePath workspace, TaskListener listener, EnvVars env,  String filepath, String coverageXmlType, io.jenkins.plugins.gcr.models.ComparisonOption comparisonOption, String coverageRateType) throws InterruptedException, IOException {
+		listener.getLogger().println("build: Attempting to parse file of type, " + coverageXmlType + "");
 
-        PluginEnvironment environment = new PluginEnvironment(run.getEnvironment(listener));
-        String githubAccessToken = PluginConfiguration.DESCRIPTOR.getGithubAccessToken();
-        String githubUrl = PluginConfiguration.DESCRIPTOR.getGithubEnterpriseUrl();
-        GithubClient githubClient = new GithubClient(environment, githubUrl, githubAccessToken);
+		PluginEnvironment environment = new PluginEnvironment(env);
+		String githubAccessToken = PluginConfiguration.DESCRIPTOR.getGithubAccessToken();
+		String githubUrl = PluginConfiguration.DESCRIPTOR.getGithubEnterpriseUrl();
+		GithubClient githubClient = new GithubClient(environment, githubUrl, githubAccessToken);
 
-        FilePath pathToFile = workspace.child(this.filepath);
+		FilePath pathToFile = workspace.child(filepath);
 
-        if (!pathToFile.exists()) {
-            listener.error("The coverage file at the provided path does not exist");
-            run.setResult(Result.FAILURE);
-            return;
-        } else {
-            listener.getLogger().println(String.format("Found file '%s'", this.filepath));
+		if (!pathToFile.exists()) {
+			listener.error("The coverage file at the provided path does not exist");
+			build.setResult(Result.FAILURE);
+			return false;
+		} else {
+			listener.getLogger().println(String.format("Found file '%s'", filepath));
 //            String xmlString = FileUtils.readFileToString(new File(pathToFile.toURI()));
-        }
+		}
 
-        BuildStepService buildStepService = new BuildStepService();
+		BuildStepService buildStepService = new BuildStepService();
 
-        try {
-            CoverageReportAction coverageReport = buildStepService.generateCoverageReport(pathToFile, comparisonOption, coverageXmlType, coverageRateType);
-            run.addAction(coverageReport);
-            run.save();
+		try {
+			CoverageReportAction coverageReport = buildStepService.generateCoverageReport(pathToFile, comparisonOption, coverageXmlType, coverageRateType);
+			build.addAction(coverageReport);
+			build.save();
 
-            GithubPayload payload = buildStepService.generateGithubCovergePayload(coverageReport, environment.getBuildUrl());
-            githubClient.sendCommitStatus(payload);
+			GithubPayload payload = buildStepService.generateGithubCovergePayload(coverageReport, environment.getBuildUrl());
+			githubClient.sendCommitStatus(payload);
 
-            run.setResult(Result.SUCCESS);
-        } catch (Exception ex) {
-            listener.error(ex.getMessage());
-            ex.printStackTrace();
-            run.setResult(Result.FAILURE);
-        }
+			build.setResult(Result.SUCCESS);
+		} catch (Exception ex) {
+			listener.error(ex.getMessage());
+			ex.printStackTrace();
+			build.setResult(Result.FAILURE);
+			return false;
+		}
+		return true;
+	}
 
-    }
-
-    @Extension
-    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+	@Extension
+	public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 
 
 
 
-        private ListBoxModel sonarProjectModel;
+		private ListBoxModel sonarProjectModel;
 
-        public ListBoxModel doFillCoverageXmlTypeItems() {
-            // TODO: localise
-            ListBoxModel model = new ListBoxModel();
-            model.add("Cobertura XML", CoverageType.COBERTURA.getIdentifier());
-            model.add("Jacoco XML", CoverageType.JACOCO.getIdentifier());
-            return model;
-        }
+		public ListBoxModel doFillCoverageXmlTypeItems() {
+			// TODO: localise
+			ListBoxModel model = new ListBoxModel();
+			model.add("Cobertura XML", CoverageType.COBERTURA.getIdentifier());
+			model.add("Jacoco XML", CoverageType.JACOCO.getIdentifier());
+			return model;
+		}
 
-        public ListBoxModel doFillSonarProjectItems() {
-            sonarProjectModel = new ListBoxModel();
+		public ListBoxModel doFillSonarProjectItems() {
+			sonarProjectModel = new ListBoxModel();
 
-            SonarClient client = new SonarClient();
-            try {
-                List<SonarProject> projects = client.listProjects();
-                projects.forEach(project -> sonarProjectModel.add(project.getName(), project.getKey()));
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+			SonarClient client = new SonarClient();
+			try {
+				List<SonarProject> projects = client.listProjects();
+				projects.forEach(project -> sonarProjectModel.add(project.getName(), project.getKey()));
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
 
-            return sonarProjectModel;
-        }
+			return sonarProjectModel;
+		}
 
-        public ListBoxModel doFillCoverageRateTypeItems() {
-            ListBoxModel model = new ListBoxModel();
-            // TODO: localise
-            model.add("Overall", CoverageRateType.OVERALL.getName());
-            model.add("Branch", CoverageRateType.BRANCH.getName());
-            model.add("Line", CoverageRateType.LINE.getName());
-            return model;
-        }
+		public ListBoxModel doFillCoverageRateTypeItems() {
+			ListBoxModel model = new ListBoxModel();
+			// TODO: localise
+			model.add("Overall", CoverageRateType.OVERALL.getName());
+			model.add("Branch", CoverageRateType.BRANCH.getName());
+			model.add("Line", CoverageRateType.LINE.getName());
+			return model;
+		}
 
-        public FormValidation doCheckSonarProject(@QueryParameter String value) {
-            // TODO: Use localized Messages strings
-            if (sonarProjectModel == null || sonarProjectModel.isEmpty()) {
-                return FormValidation.error("SonarQube server unreachable.");
-            }
-            if (value == null || value.equals("")) {
-                return FormValidation.error("Invalid project selection. check that your SonarQube server is not unreachable.");
-            }
+		public FormValidation doCheckSonarProject(@QueryParameter String value) {
+			// TODO: Use localized Messages strings
+			if (sonarProjectModel == null || sonarProjectModel.isEmpty()) {
+				return FormValidation.error("SonarQube server unreachable.");
+			}
+			if (value == null || value.equals("")) {
+				return FormValidation.error("Invalid project selection. check that your SonarQube server is not unreachable.");
+			}
 
-            return FormValidation.ok();
-        }
+			return FormValidation.ok();
+		}
 
-        @Override
-        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
-            return true;
-        }
+		@Override
+		public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+			return true;
+		}
 
-        @Override
-        public String getDisplayName() {
-            return Messages.GithubCoveragePublisher_DescriptorImpl_DisplayName();
-        }
+		@Override
+		public String getDisplayName() {
+			return Messages.GithubCoveragePublisher_DescriptorImpl_DisplayName();
+		}
 
-    }
+	}
 
-    @Override
-    public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.NONE;
-    }
+	@Override
+	public BuildStepMonitor getRequiredMonitorService() {
+		return BuildStepMonitor.NONE;
+	}
 }

--- a/src/main/java/io/jenkins/plugins/gcr/models/PluginEnvironment.java
+++ b/src/main/java/io/jenkins/plugins/gcr/models/PluginEnvironment.java
@@ -17,16 +17,21 @@ public class PluginEnvironment {
     // Constructor
 
     public PluginEnvironment(EnvVars env) throws IllegalArgumentException {
-    	String changeUrl = get("CHANGE_URL", env);
+        if (env.containsKey("ghprbGhRepository") && env.containsKey("ghprbActualCommit")) {
+            pullRequestRepository = get("ghprbGhRepository", env);
+            gitHash = get("ghprbActualCommit", env);
+        } else{
+            String changeUrl = get("CHANGE_URL", env);
 
-		Pattern pattern = Pattern.compile("https://github.com/(.*?)/pull/.*");
-		Matcher matcher = pattern.matcher(changeUrl);
-		if (matcher.find()) {
-			pullRequestRepository=matcher.group(1);
-		} else {
-			throw new IllegalArgumentException(String.format("Can't find the owner/repo from CHANGE_URL environmental variable '%s'", changeUrl));
-		}
-        gitHash = get("GIT_COMMIT", env);
+            Pattern pattern = Pattern.compile("https://[^/]*/(.*?)/pull/.*");
+            Matcher matcher = pattern.matcher(changeUrl);
+            if (matcher.find()) {
+                pullRequestRepository = matcher.group(1);
+            } else {
+                throw new IllegalArgumentException(String.format("Can't find the owner/repo from CHANGE_URL environmental variable '%s'", changeUrl));
+            }
+            gitHash = get("GIT_COMMIT", env);
+        }
         buildUrl = get("BUILD_URL", env);
     }
 

--- a/src/main/java/io/jenkins/plugins/gcr/models/PluginEnvironment.java
+++ b/src/main/java/io/jenkins/plugins/gcr/models/PluginEnvironment.java
@@ -3,13 +3,12 @@ package io.jenkins.plugins.gcr.models;
 import hudson.EnvVars;
 import hudson.model.Run;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class PluginEnvironment {
 
-    private String pullRequestId;
-
     private String pullRequestRepository;
-
-    private String gitUrl;
 
     private String gitHash;
 
@@ -18,22 +17,20 @@ public class PluginEnvironment {
     // Constructor
 
     public PluginEnvironment(EnvVars env) throws IllegalArgumentException {
-        pullRequestId = get("ghprbPullId", env);
-        pullRequestRepository = get("ghprbGhRepository", env);
-        gitUrl = get("ghprbAuthorRepoGitUrl", env);
-        gitHash = get("ghprbActualCommit", env);
+    	String changeUrl = get("CHANGE_URL", env);
+
+		Pattern pattern = Pattern.compile("https://github.com/(.*?)/pull/.*");
+		Matcher matcher = pattern.matcher(changeUrl);
+		if (matcher.find()) {
+			pullRequestRepository=matcher.group(1);
+		} else {
+			throw new IllegalArgumentException(String.format("Can't find the owner/repo from CHANGE_URL environmental variable '%s'", changeUrl));
+		}
+        gitHash = get("GIT_COMMIT", env);
         buildUrl = get("BUILD_URL", env);
     }
 
     // Getters / Setters
-
-    public String getPullRequestId() {
-        return pullRequestId;
-    }
-
-    public String getGitUrl() {
-        return gitUrl;
-    }
 
     public String getGitHash() {
         return gitHash;

--- a/src/main/java/io/jenkins/plugins/gcr/parsers/CoberturaParser.java
+++ b/src/main/java/io/jenkins/plugins/gcr/parsers/CoberturaParser.java
@@ -27,7 +27,7 @@ public class CoberturaParser implements CoverageParser {
 
             return coverage;
         } catch (Exception ex) {
-            String message = String.format("Failed to parse Jacoco coverage for filepath '%s'", filepath);
+            String message = String.format("Failed to parse Cobertura coverage for filepath '%s'", filepath);
             throw new ParserException(message, ex);
         }
     }

--- a/src/main/java/io/jenkins/plugins/gcr/workflow/PublishCoverageStep.java
+++ b/src/main/java/io/jenkins/plugins/gcr/workflow/PublishCoverageStep.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.gcr.workflow;
 
 import io.jenkins.plugins.gcr.GithubCoveragePublisher;
 import hudson.Extension;
+
 import javax.annotation.CheckForNull;
 
 import io.jenkins.plugins.gcr.models.ComparisonOption;
@@ -14,55 +15,59 @@ import java.io.IOException;
 
 /**
  * Publishes code coverage to Github in Workflows.
+ *
  * @author Nicolas Zin
  */
 public class PublishCoverageStep extends AbstractStepImpl {
 
-	private String filepath;
+    private String filepath;
 
-	private String coverageXmlType;
+    private String coverageXmlType;
 
-	private String coverageRateType;
+    private String coverageRateType;
 
-	private ComparisonOption comparisonOption;
+    private ComparisonOption comparisonOption;
 
-	@DataBoundConstructor
-	public PublishCoverageStep(String filepath, String coverageXmlType, String coverageRateType, ComparisonOption comparisonOption) throws IOException {
-		this.filepath = filepath;
-		this.coverageXmlType = coverageXmlType;
-		this.coverageRateType = coverageRateType;
-		this.comparisonOption = comparisonOption;
-	}
+    @DataBoundConstructor
+    public PublishCoverageStep(String filepath, String coverageXmlType, String coverageRateType, ComparisonOption comparisonOption) throws IOException {
+        this.filepath = filepath;
+        this.coverageXmlType = coverageXmlType;
+        this.coverageRateType = coverageRateType;
+        this.comparisonOption = comparisonOption;
+    }
 
-	public String getFilePath() {
-		return filepath;
-	}
-	public String getCoverageXmlType() {
-		return coverageXmlType;
-	}
-	public String getCoverageRateType() {
-		return coverageRateType;
-	}
-	public ComparisonOption getComparisonOption() {
-		return comparisonOption;
-	}
+    public String getFilePath() {
+        return filepath;
+    }
+
+    public String getCoverageXmlType() {
+        return coverageXmlType;
+    }
+
+    public String getCoverageRateType() {
+        return coverageRateType;
+    }
+
+    public ComparisonOption getComparisonOption() {
+        return comparisonOption;
+    }
 
 
-	@Extension
-	public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
 
-		public DescriptorImpl() {
-			super(PublishCoverageStepExecution.class);
-		}
+        public DescriptorImpl() {
+            super(PublishCoverageStepExecution.class);
+        }
 
-		@Override
-		public String getFunctionName() {
-			return "publishCoverageGithub";
-		}
+        @Override
+        public String getFunctionName() {
+            return "publishCoverageGithub";
+        }
 
-		@Override
-		public String getDisplayName() {
-			return "Publish Coverage reports to Github";
-		}
-	}
+        @Override
+        public String getDisplayName() {
+            return "Publish Coverage reports to Github";
+        }
+    }
 }

--- a/src/main/java/io/jenkins/plugins/gcr/workflow/PublishCoverageStep.java
+++ b/src/main/java/io/jenkins/plugins/gcr/workflow/PublishCoverageStep.java
@@ -1,0 +1,68 @@
+package io.jenkins.plugins.gcr.workflow;
+
+import io.jenkins.plugins.gcr.GithubCoveragePublisher;
+import hudson.Extension;
+import javax.annotation.CheckForNull;
+
+import io.jenkins.plugins.gcr.models.ComparisonOption;
+import io.jenkins.plugins.gcr.workflow.PublishCoverageStepExecution;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+
+/**
+ * Publishes code coverage to Github in Workflows.
+ * @author Nicolas Zin
+ */
+public class PublishCoverageStep extends AbstractStepImpl {
+
+	private String filepath;
+
+	private String coverageXmlType;
+
+	private String coverageRateType;
+
+	private ComparisonOption comparisonOption;
+
+	@DataBoundConstructor
+	public PublishCoverageStep(String filepath, String coverageXmlType, String coverageRateType, ComparisonOption comparisonOption) throws IOException {
+		this.filepath = filepath;
+		this.coverageXmlType = coverageXmlType;
+		this.coverageRateType = coverageRateType;
+		this.comparisonOption = comparisonOption;
+	}
+
+	public String getFilePath() {
+		return filepath;
+	}
+	public String getCoverageXmlType() {
+		return coverageXmlType;
+	}
+	public String getCoverageRateType() {
+		return coverageRateType;
+	}
+	public ComparisonOption getComparisonOption() {
+		return comparisonOption;
+	}
+
+
+	@Extension
+	public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+		public DescriptorImpl() {
+			super(PublishCoverageStepExecution.class);
+		}
+
+		@Override
+		public String getFunctionName() {
+			return "publishCoverageGithub";
+		}
+
+		@Override
+		public String getDisplayName() {
+			return "Publish Coverage reports to Github";
+		}
+	}
+}

--- a/src/main/java/io/jenkins/plugins/gcr/workflow/PublishCoverageStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/gcr/workflow/PublishCoverageStepExecution.java
@@ -1,0 +1,55 @@
+package io.jenkins.plugins.gcr.workflow;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import javax.inject.Inject;
+
+import hudson.EnvVars;
+import hudson.model.BuildListener;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+
+import hudson.AbortException;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import io.jenkins.plugins.gcr.GithubCoveragePublisher;
+
+/**
+ * Execution for {@link PublishCoverageStep}.
+ * @author Nicolas Zin
+ */
+public class PublishCoverageStepExecution extends AbstractSynchronousNonBlockingStepExecution<Void> {
+	private static final long serialVersionUID = 1L;
+
+	@StepContextParameter
+	private transient TaskListener listener;
+
+	@StepContextParameter
+	private transient FilePath ws;
+
+	@StepContextParameter
+	private transient Run build;
+
+	@StepContextParameter
+	private transient Launcher launcher;
+
+	@Inject
+	private transient PublishCoverageStep step;
+
+	@Override
+	protected Void run() throws Exception {
+		StepContext context = getContext();
+		EnvVars env = context.get(EnvVars.class);
+
+		boolean res = GithubCoveragePublisher.publishCoverage(build, ws, listener, env, step.getFilePath(), step.getCoverageXmlType(), step.getComparisonOption(), step.getCoverageRateType());
+		if (!res) {
+			throw new AbortException("Cannot publish coverage report");
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/io/jenkins/plugins/gcr/workflow/PublishCoverageStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/gcr/workflow/PublishCoverageStepExecution.java
@@ -20,36 +20,37 @@ import io.jenkins.plugins.gcr.GithubCoveragePublisher;
 
 /**
  * Execution for {@link PublishCoverageStep}.
+ *
  * @author Nicolas Zin
  */
 public class PublishCoverageStepExecution extends AbstractSynchronousNonBlockingStepExecution<Void> {
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	@StepContextParameter
-	private transient TaskListener listener;
+    @StepContextParameter
+    private transient TaskListener listener;
 
-	@StepContextParameter
-	private transient FilePath ws;
+    @StepContextParameter
+    private transient FilePath ws;
 
-	@StepContextParameter
-	private transient Run build;
+    @StepContextParameter
+    private transient Run build;
 
-	@StepContextParameter
-	private transient Launcher launcher;
+    @StepContextParameter
+    private transient Launcher launcher;
 
-	@Inject
-	private transient PublishCoverageStep step;
+    @Inject
+    private transient PublishCoverageStep step;
 
-	@Override
-	protected Void run() throws Exception {
-		StepContext context = getContext();
-		EnvVars env = context.get(EnvVars.class);
+    @Override
+    protected Void run() throws Exception {
+        StepContext context = getContext();
+        EnvVars env = context.get(EnvVars.class);
 
-		boolean res = GithubCoveragePublisher.publishCoverage(build, ws, listener, env, step.getFilePath(), step.getCoverageXmlType(), step.getComparisonOption(), step.getCoverageRateType());
-		if (!res) {
-			throw new AbortException("Cannot publish coverage report");
-		}
-		return null;
-	}
+        boolean res = GithubCoveragePublisher.publishCoverage(build, ws, listener, env, step.getFilePath(), step.getCoverageXmlType(), step.getComparisonOption(), step.getCoverageRateType());
+        if (!res) {
+            throw new AbortException("Cannot publish coverage report");
+        }
+        return null;
+    }
 
 }

--- a/src/test/java/io/jenkins/plugins/gcr/GithubClientTests.java
+++ b/src/test/java/io/jenkins/plugins/gcr/GithubClientTests.java
@@ -57,7 +57,7 @@ public class GithubClientTests {
 
     private PluginEnvironment createMockEnvironment() {
         EnvVars envVars = new EnvVars(
-                "CHANGE_URL", "https://github.com/"+REPO+"/pull/130",
+                "CHANGE_URL", "https://github.com/" + REPO + "/pull/130",
                 "GIT_COMMIT", COMMIT_HASH,
                 "BUILD_URL", "https://my.build/url"
         );

--- a/src/test/java/io/jenkins/plugins/gcr/GithubClientTests.java
+++ b/src/test/java/io/jenkins/plugins/gcr/GithubClientTests.java
@@ -20,6 +20,31 @@ public class GithubClientTests {
     private static final String ACCESS_TOKEN = "abc123";
 
     @Test
+    public void testGhprbGithubClient() throws Exception {
+
+        PluginEnvironment mockEnvironment = createGhprbMockEnvironment();
+        HttpClientMock mockClient = new HttpClientMock();
+        GithubPayload payload = createMockPayload();
+
+        File mockFile = TestUtils.loadResource("github-status.json");
+
+        String url = String.format("https://api.github.com/repos/%s/statuses/%s", REPO, COMMIT_HASH);
+
+        mockClient.onPost(url)
+                .withParameter("access_token", ACCESS_TOKEN)
+                .doReturnStatus(201)
+                .doReturn(Files.toString(mockFile, Charset.forName("utf-8")));
+
+        GithubClient client = new GithubClient(mockEnvironment, null, ACCESS_TOKEN, mockClient);
+
+        try {
+            client.sendCommitStatus(payload);
+        } catch (GithubClientException ex) {
+            Assert.fail();
+        }
+    }
+
+    @Test
     public void testGithubClient() throws Exception {
 
         PluginEnvironment mockEnvironment = createMockEnvironment();
@@ -67,4 +92,17 @@ public class GithubClientTests {
         return environment;
     }
 
+    private PluginEnvironment createGhprbMockEnvironment() {
+        EnvVars envVars = new EnvVars(
+                "ghprbPullId", "34",
+                "ghprbGhRepository", REPO,
+                "ghprbAuthorRepoGitUrl", "https://api.github.com",
+                "ghprbActualCommit", COMMIT_HASH,
+                "BUILD_URL", "https://my.build/url"
+        );
+
+        PluginEnvironment environment = new PluginEnvironment(envVars);
+
+        return environment;
+    }
 }

--- a/src/test/java/io/jenkins/plugins/gcr/GithubClientTests.java
+++ b/src/test/java/io/jenkins/plugins/gcr/GithubClientTests.java
@@ -57,10 +57,8 @@ public class GithubClientTests {
 
     private PluginEnvironment createMockEnvironment() {
         EnvVars envVars = new EnvVars(
-                "ghprbPullId", "34",
-                "ghprbGhRepository", REPO,
-                "ghprbAuthorRepoGitUrl", "https://api.github.com",
-                "ghprbActualCommit", COMMIT_HASH,
+                "CHANGE_URL", "https://github.com/"+REPO+"/pull/130",
+                "GIT_COMMIT", COMMIT_HASH,
                 "BUILD_URL", "https://my.build/url"
         );
 


### PR DESCRIPTION
In this PR:
- I dont use ghprbPullId, ghprbGhRepository, ... but use GIT_COMMIT, CHANGE_ID, ... which seems to be more versatile
- I add possibility to use it into Jenkinsfile.

For example
```
        stage('Testing...') {
            steps {
                ...
            }
            post {
                success {
                    publishCoverageGithub(filepath:'coverage.xml', coverageXmlType: 'cobertura', comparisonOption: [ value: 'optionFixedCoverage', fixedCoverage: '0.65' ], coverageRateType: 'Line')
                }
            }
        }
```

The Jenkinsfile has been tested successfully